### PR TITLE
Remove schema version check

### DIFF
--- a/pyxb/binding/generate.py
+++ b/pyxb/binding/generate.py
@@ -1242,9 +1242,6 @@ _GenerationUID = %{generation_uid_expr}
 
 # Version of PyXB used to generate the bindings
 _PyXBVersion = %{pyxb_version}
-# Generated bindings are not compatible across PyXB versions
-if pyxb.__version__ != _PyXBVersion:
-    raise pyxb.PyXBVersionError(_PyXBVersion)
 
 # A holder for module-level binding classes so we can access them from
 # inside class definitions where property names may conflict.


### PR DESCRIPTION
Upstream PyXB has ceased active development. This fork exists to provide security and compatibility fixes only, and therefore we do not anticipate any further breaking changes.

In cases where breaking changes do occur, we can add version checks in retroactively. 

Furthermore, if users need version checks, they can use the `_PyXBVersion` constant within the generated schema to manually run a version check.