### PR TITLE
Add Python 3.12 compatibility

### DIFF
--- a/pyxb/namespace/archive.py
+++ b/pyxb/namespace/archive.py
@@ -110,7 +110,7 @@ class NamespaceArchive (object):
         rv._readToStage(stage)
         return rv
 
-    __ArchivePattern_re = re.compile('\.wxs$')
+    __ArchivePattern_re = re.compile(r'\.wxs$')
 
     @classmethod
     def PreLoadArchives (cls, archive_path=None, reset=False):

--- a/pyxb/utils/six.py
+++ b/pyxb/utils/six.py
@@ -31,6 +31,7 @@ import types
 __author__ = "Benjamin Peterson <benjamin@python.org>"
 __version__ = "1.9.0"
 
+
 # Useful for very coarse version differentiation.
 PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
@@ -61,7 +62,6 @@ else:
     binary_type = str
 
     import types
-
     none_type = types.NoneType
     boolean_type = types.BooleanType
     int_type = types.IntType
@@ -80,8 +80,6 @@ else:
 
             def __len__(self):
                 return 1 << 31
-
-
         try:
             len(X())
         except OverflowError:
@@ -250,7 +248,8 @@ class _SixMetaPathImporter:
 
     def is_package(self, fullname):
         """
-        Return true if the named module is a package.
+        Return true, if the named module is a package.
+
         We need this method to get correct spec objects with
         Python 3.4 (see PEP451)
         """
@@ -262,14 +261,13 @@ class _SixMetaPathImporter:
         Required, if is_package is implemented"""
         self.__get_module(fullname)  # eventually raises ImportError
         return None
-
     get_source = get_code  # same as get_code
-
 
 _importer = _SixMetaPathImporter(__name__)
 
 
 class _MovedItems(_LazyModule):
+
     """Lazy loading of moved objects"""
     __path__ = []  # mark as package
 
@@ -361,6 +359,7 @@ _importer._add_module(moves, "moves")
 
 
 class Module_six_moves_urllib_parse(_LazyModule):
+
     """Lazy loading of moved objects in six.moves.urllib_parse"""
 
 
@@ -400,6 +399,7 @@ _importer._add_module(Module_six_moves_urllib_parse(__name__ + ".moves.urllib_pa
 
 
 class Module_six_moves_urllib_error(_LazyModule):
+
     """Lazy loading of moved objects in six.moves.urllib_error"""
 
 
@@ -419,6 +419,7 @@ _importer._add_module(Module_six_moves_urllib_error(__name__ + ".moves.urllib.er
 
 
 class Module_six_moves_urllib_request(_LazyModule):
+
     """Lazy loading of moved objects in six.moves.urllib_request"""
 
 
@@ -488,6 +489,7 @@ _importer._add_module(Module_six_moves_urllib_response(__name__ + ".moves.urllib
 
 
 class Module_six_moves_urllib_robotparser(_LazyModule):
+
     """Lazy loading of moved objects in six.moves.urllib_robotparser"""
 
 
@@ -505,6 +507,7 @@ _importer._add_module(Module_six_moves_urllib_robotparser(__name__ + ".moves.url
 
 
 class Module_six_moves_urllib(types.ModuleType):
+
     """Create a six.moves.urllib namespace that resembles the Python 3 namespace"""
     __path__ = []  # mark as package
     parse = _importer._get_module("moves.urllib_parse")
@@ -554,6 +557,7 @@ else:
     _func_defaults = "func_defaults"
     _func_globals = "func_globals"
 
+
 try:
     advance_iterator = next
 except NameError:
@@ -561,43 +565,38 @@ except NameError:
         return it.next()
 next = advance_iterator
 
+
 try:
     callable = callable
 except NameError:
     def callable(obj):
         return any("__call__" in klass.__dict__ for klass in type(obj).__mro__)
 
+
 if PY3:
     def get_unbound_function(unbound):
         return unbound
 
-
     create_bound_method = types.MethodType
-
 
     def create_unbound_method(func, cls):
         return func
-
 
     Iterator = object
 else:
     def get_unbound_function(unbound):
         return unbound.im_func
 
-
     def create_bound_method(func, obj):
         return types.MethodType(func, obj, obj.__class__)
 
-
     def create_unbound_method(func, cls):
         return types.MethodType(func, None, cls)
-
 
     class Iterator(object):
 
         def next(self):
             return type(self).__next__(self)
-
 
     callable = callable
 _add_doc(get_unbound_function,
@@ -610,22 +609,19 @@ get_function_code = operator.attrgetter(_func_code)
 get_function_defaults = operator.attrgetter(_func_defaults)
 get_function_globals = operator.attrgetter(_func_globals)
 
+
 if PY3:
     def iterkeys(d, **kw):
         return iter(d.keys(**kw))
 
-
     def itervalues(d, **kw):
         return iter(d.values(**kw))
-
 
     def iteritems(d, **kw):
         return iter(d.items(**kw))
 
-
     def iterlists(d, **kw):
         return iter(d.lists(**kw))
-
 
     viewkeys = operator.methodcaller("keys")
 
@@ -636,18 +632,14 @@ else:
     def iterkeys(d, **kw):
         return d.iterkeys(**kw)
 
-
     def itervalues(d, **kw):
         return d.itervalues(**kw)
-
 
     def iteritems(d, **kw):
         return d.iteritems(**kw)
 
-
     def iterlists(d, **kw):
         return d.iterlists(**kw)
-
 
     viewkeys = operator.methodcaller("viewkeys")
 
@@ -662,25 +654,21 @@ _add_doc(iteritems,
 _add_doc(iterlists,
          "Return an iterator over the (key, [values]) pairs of a dictionary.")
 
+
 if PY3:
     def b(s):
         return s.encode("latin-1")
 
-
     def u(s):
         return s
-
-
     unichr = chr
     import struct
-
     int2byte = struct.Struct(">B").pack
     del struct
     byte2int = operator.itemgetter(0)
     indexbytes = operator.getitem
     iterbytes = iter
     import io
-
     StringIO = io.StringIO
     BytesIO = io.BytesIO
     file = io.IOBase
@@ -694,29 +682,20 @@ if PY3:
 else:
     def b(s):
         return s
-
-
     # Workaround for standalone backslash
 
     def u(s):
         return unicode(s.replace(r'\\', r'\\\\'), "unicode_escape")
-
-
     unichr = unichr
     int2byte = chr
-
 
     def byte2int(bs):
         return ord(bs[0])
 
-
     def indexbytes(buf, i):
         return ord(buf[i])
-
-
     iterbytes = functools.partial(itertools.imap, ord)
     import StringIO
-
     StringIO = BytesIO = StringIO.StringIO
     _assertCountEqual = "assertItemsEqual"
     _assertRaisesRegex = "assertRaisesRegexp"
@@ -740,7 +719,6 @@ def assertRegex(self, *args, **kwargs):
 if PY3:
     exec_ = getattr(moves.builtins, "exec")
 
-
     def reraise(tp, value, tb=None):
         if value is None:
             value = tp()
@@ -761,10 +739,10 @@ else:
             _locs_ = _globs_
         exec("""exec _code_ in _globs_, _locs_""")
 
-
     exec_("""def reraise(tp, value, tb=None):
     raise tp, value, tb
 """)
+
 
 if sys.version_info[:2] == (3, 2):
     exec_("""def raise_from(value, from_value):
@@ -779,6 +757,7 @@ elif sys.version_info[:2] > (3, 2):
 else:
     def raise_from(value, from_value):
         raise value
+
 
 print_ = getattr(moves.builtins, "print", None)
 if print_ is None:
@@ -839,7 +818,6 @@ if print_ is None:
 if sys.version_info[:2] < (3, 3):
     _print = print_
 
-
     def print_(*args, **kwargs):
         fp = kwargs.get("file", sys.stdout)
         flush = kwargs.pop("flush", False)
@@ -856,7 +834,6 @@ if sys.version_info[0:2] < (3, 4):
             f = functools.wraps(wrapped, assigned, updated)(f)
             f.__wrapped__ = wrapped
             return f
-
         return wrapper
 else:
     wraps = functools.wraps
@@ -864,7 +841,6 @@ else:
 
 def with_metaclass(meta, *bases):
     """Create a base class with a metaclass."""
-
     # This requires a bit of explanation: the basic idea is to make a dummy
     # metaclass for one level of class instantiation that replaces itself with
     # the actual metaclass.
@@ -872,13 +848,11 @@ def with_metaclass(meta, *bases):
 
         def __new__(cls, name, this_bases, d):
             return meta(name, bases, d)
-
     return type.__new__(metaclass, 'temporary_class', (), {})
 
 
 def add_metaclass(metaclass):
     """Class decorator for creating a class with a metaclass."""
-
     def wrapper(cls):
         orig_vars = cls.__dict__.copy()
         slots = orig_vars.get('__slots__')
@@ -890,7 +864,6 @@ def add_metaclass(metaclass):
         orig_vars.pop('__dict__', None)
         orig_vars.pop('__weakref__', None)
         return metaclass(cls.__name__, cls.__bases__, orig_vars)
-
     return wrapper
 
 

--- a/pyxb/utils/six.py
+++ b/pyxb/utils/six.py
@@ -469,6 +469,7 @@ _importer._add_module(Module_six_moves_urllib_request(__name__ + ".moves.urllib.
 
 
 class Module_six_moves_urllib_response(_LazyModule):
+
     """Lazy loading of moved objects in six.moves.urllib_response"""
 
 
@@ -518,7 +519,6 @@ class Module_six_moves_urllib(types.ModuleType):
 
     def __dir__(self):
         return ['parse', 'error', 'request', 'response', 'robotparser']
-
 
 _importer._add_module(Module_six_moves_urllib(__name__ + ".moves.urllib"),
                       "moves.urllib")
@@ -601,6 +601,7 @@ else:
     callable = callable
 _add_doc(get_unbound_function,
          """Get the function out of a possibly unbound function""")
+
 
 get_method_function = operator.attrgetter(_meth_func)
 get_method_self = operator.attrgetter(_meth_self)
@@ -779,7 +780,6 @@ if print_ is None:
                     errors = "strict"
                 data = data.encode(fp.encoding, errors)
             fp.write(data)
-
         want_unicode = False
         sep = kwargs.pop("sep", None)
         if sep is not None:

--- a/pyxb/utils/six.py
+++ b/pyxb/utils/six.py
@@ -23,7 +23,6 @@
 from __future__ import absolute_import
 
 import functools
-import importlib.util
 import itertools
 import operator
 import sys
@@ -211,6 +210,7 @@ class _SixMetaPathImporter:
         return None
 
     def find_spec(self, fullname, path=None, target=None):
+        import importlib.util
         if fullname in self.known_modules:
             spec = importlib.util.spec_from_loader(fullname, self)
             return spec

--- a/pyxb/utils/six.py
+++ b/pyxb/utils/six.py
@@ -32,7 +32,6 @@ import types
 __author__ = "Benjamin Peterson <benjamin@python.org>"
 __version__ = "1.9.0"
 
-
 # Useful for very coarse version differentiation.
 PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
@@ -63,6 +62,7 @@ else:
     binary_type = str
 
     import types
+
     none_type = types.NoneType
     boolean_type = types.BooleanType
     int_type = types.IntType
@@ -81,6 +81,8 @@ else:
 
             def __len__(self):
                 return 1 << 31
+
+
         try:
             len(X())
         except OverflowError:
@@ -182,6 +184,12 @@ class MovedAttribute(_LazyDescr):
 
 
 class _SixMetaPathImporter:
+    """
+    A meta path importer to import six.moves and its submodules.
+
+    This class implemented a PEP 451 finder and loader. It should be compatible
+    with Python 3.4 onwards.
+    """
 
     def __init__(self, six_module_name):
         self.name = six_module_name
@@ -234,11 +242,12 @@ class _SixMetaPathImporter:
         return None
 
     get_source = get_code  # same as get_code
+
+
 _importer = _SixMetaPathImporter(__name__)
 
 
 class _MovedItems(_LazyModule):
-
     """Lazy loading of moved objects"""
     __path__ = []  # mark as package
 
@@ -330,7 +339,6 @@ _importer._add_module(moves, "moves")
 
 
 class Module_six_moves_urllib_parse(_LazyModule):
-
     """Lazy loading of moved objects in six.moves.urllib_parse"""
 
 
@@ -370,7 +378,6 @@ _importer._add_module(Module_six_moves_urllib_parse(__name__ + ".moves.urllib_pa
 
 
 class Module_six_moves_urllib_error(_LazyModule):
-
     """Lazy loading of moved objects in six.moves.urllib_error"""
 
 
@@ -390,7 +397,6 @@ _importer._add_module(Module_six_moves_urllib_error(__name__ + ".moves.urllib.er
 
 
 class Module_six_moves_urllib_request(_LazyModule):
-
     """Lazy loading of moved objects in six.moves.urllib_request"""
 
 
@@ -440,7 +446,6 @@ _importer._add_module(Module_six_moves_urllib_request(__name__ + ".moves.urllib.
 
 
 class Module_six_moves_urllib_response(_LazyModule):
-
     """Lazy loading of moved objects in six.moves.urllib_response"""
 
 
@@ -461,7 +466,6 @@ _importer._add_module(Module_six_moves_urllib_response(__name__ + ".moves.urllib
 
 
 class Module_six_moves_urllib_robotparser(_LazyModule):
-
     """Lazy loading of moved objects in six.moves.urllib_robotparser"""
 
 
@@ -479,7 +483,6 @@ _importer._add_module(Module_six_moves_urllib_robotparser(__name__ + ".moves.url
 
 
 class Module_six_moves_urllib(types.ModuleType):
-
     """Create a six.moves.urllib namespace that resembles the Python 3 namespace"""
     __path__ = []  # mark as package
     parse = _importer._get_module("moves.urllib_parse")
@@ -490,6 +493,7 @@ class Module_six_moves_urllib(types.ModuleType):
 
     def __dir__(self):
         return ['parse', 'error', 'request', 'response', 'robotparser']
+
 
 _importer._add_module(Module_six_moves_urllib(__name__ + ".moves.urllib"),
                       "moves.urllib")
@@ -528,7 +532,6 @@ else:
     _func_defaults = "func_defaults"
     _func_globals = "func_globals"
 
-
 try:
     advance_iterator = next
 except NameError:
@@ -536,43 +539,47 @@ except NameError:
         return it.next()
 next = advance_iterator
 
-
 try:
     callable = callable
 except NameError:
     def callable(obj):
         return any("__call__" in klass.__dict__ for klass in type(obj).__mro__)
 
-
 if PY3:
     def get_unbound_function(unbound):
         return unbound
 
+
     create_bound_method = types.MethodType
+
 
     def create_unbound_method(func, cls):
         return func
+
 
     Iterator = object
 else:
     def get_unbound_function(unbound):
         return unbound.im_func
 
+
     def create_bound_method(func, obj):
         return types.MethodType(func, obj, obj.__class__)
 
+
     def create_unbound_method(func, cls):
         return types.MethodType(func, None, cls)
+
 
     class Iterator(object):
 
         def next(self):
             return type(self).__next__(self)
 
+
     callable = callable
 _add_doc(get_unbound_function,
          """Get the function out of a possibly unbound function""")
-
 
 get_method_function = operator.attrgetter(_meth_func)
 get_method_self = operator.attrgetter(_meth_self)
@@ -581,19 +588,22 @@ get_function_code = operator.attrgetter(_func_code)
 get_function_defaults = operator.attrgetter(_func_defaults)
 get_function_globals = operator.attrgetter(_func_globals)
 
-
 if PY3:
     def iterkeys(d, **kw):
         return iter(d.keys(**kw))
 
+
     def itervalues(d, **kw):
         return iter(d.values(**kw))
+
 
     def iteritems(d, **kw):
         return iter(d.items(**kw))
 
+
     def iterlists(d, **kw):
         return iter(d.lists(**kw))
+
 
     viewkeys = operator.methodcaller("keys")
 
@@ -604,14 +614,18 @@ else:
     def iterkeys(d, **kw):
         return d.iterkeys(**kw)
 
+
     def itervalues(d, **kw):
         return d.itervalues(**kw)
+
 
     def iteritems(d, **kw):
         return d.iteritems(**kw)
 
+
     def iterlists(d, **kw):
         return d.iterlists(**kw)
+
 
     viewkeys = operator.methodcaller("viewkeys")
 
@@ -626,21 +640,25 @@ _add_doc(iteritems,
 _add_doc(iterlists,
          "Return an iterator over the (key, [values]) pairs of a dictionary.")
 
-
 if PY3:
     def b(s):
         return s.encode("latin-1")
 
+
     def u(s):
         return s
+
+
     unichr = chr
     import struct
+
     int2byte = struct.Struct(">B").pack
     del struct
     byte2int = operator.itemgetter(0)
     indexbytes = operator.getitem
     iterbytes = iter
     import io
+
     StringIO = io.StringIO
     BytesIO = io.BytesIO
     file = io.IOBase
@@ -654,20 +672,29 @@ if PY3:
 else:
     def b(s):
         return s
+
+
     # Workaround for standalone backslash
 
     def u(s):
         return unicode(s.replace(r'\\', r'\\\\'), "unicode_escape")
+
+
     unichr = unichr
     int2byte = chr
+
 
     def byte2int(bs):
         return ord(bs[0])
 
+
     def indexbytes(buf, i):
         return ord(buf[i])
+
+
     iterbytes = functools.partial(itertools.imap, ord)
     import StringIO
+
     StringIO = BytesIO = StringIO.StringIO
     _assertCountEqual = "assertItemsEqual"
     _assertRaisesRegex = "assertRaisesRegexp"
@@ -691,6 +718,7 @@ def assertRegex(self, *args, **kwargs):
 if PY3:
     exec_ = getattr(moves.builtins, "exec")
 
+
     def reraise(tp, value, tb=None):
         if value is None:
             value = tp()
@@ -711,10 +739,10 @@ else:
             _locs_ = _globs_
         exec("""exec _code_ in _globs_, _locs_""")
 
+
     exec_("""def reraise(tp, value, tb=None):
     raise tp, value, tb
 """)
-
 
 if sys.version_info[:2] == (3, 2):
     exec_("""def raise_from(value, from_value):
@@ -729,7 +757,6 @@ elif sys.version_info[:2] > (3, 2):
 else:
     def raise_from(value, from_value):
         raise value
-
 
 print_ = getattr(moves.builtins, "print", None)
 if print_ is None:
@@ -751,6 +778,7 @@ if print_ is None:
                     errors = "strict"
                 data = data.encode(fp.encoding, errors)
             fp.write(data)
+
         want_unicode = False
         sep = kwargs.pop("sep", None)
         if sep is not None:
@@ -789,6 +817,7 @@ if print_ is None:
 if sys.version_info[:2] < (3, 3):
     _print = print_
 
+
     def print_(*args, **kwargs):
         fp = kwargs.get("file", sys.stdout)
         flush = kwargs.pop("flush", False)
@@ -805,6 +834,7 @@ if sys.version_info[0:2] < (3, 4):
             f = functools.wraps(wrapped, assigned, updated)(f)
             f.__wrapped__ = wrapped
             return f
+
         return wrapper
 else:
     wraps = functools.wraps
@@ -812,6 +842,7 @@ else:
 
 def with_metaclass(meta, *bases):
     """Create a base class with a metaclass."""
+
     # This requires a bit of explanation: the basic idea is to make a dummy
     # metaclass for one level of class instantiation that replaces itself with
     # the actual metaclass.
@@ -819,11 +850,13 @@ def with_metaclass(meta, *bases):
 
         def __new__(cls, name, this_bases, d):
             return meta(name, bases, d)
+
     return type.__new__(metaclass, 'temporary_class', (), {})
 
 
 def add_metaclass(metaclass):
     """Class decorator for creating a class with a metaclass."""
+
     def wrapper(cls):
         orig_vars = cls.__dict__.copy()
         slots = orig_vars.get('__slots__')
@@ -835,6 +868,7 @@ def add_metaclass(metaclass):
         orig_vars.pop('__dict__', None)
         orig_vars.pop('__weakref__', None)
         return metaclass(cls.__name__, cls.__bases__, orig_vars)
+
     return wrapper
 
 

--- a/setup.py
+++ b/setup.py
@@ -42,8 +42,8 @@ packages = [
 ]
 package_data = {}
 
-init_re = re.compile("^__init__\.py$")
-wxs_re = re.compile("^.*\.wxs$")
+init_re = re.compile(r"^__init__\.py$")
+wxs_re = re.compile(r"^.*\.wxs$")
 
 setup_path = os.path.dirname(__file__)
 bundle_base = os.path.join(setup_path, "pyxb", "bundles")


### PR DESCRIPTION
With Version `3.12`, the deprecated [PEP302](https://peps.python.org/pep-0302/) import hooks were removed, leading to import errors as the `_SixMetaPathImporter` did no longer work.

This pull request introduces the [PEP451](https://peps.python.org/pep-0451/) methods `find_spec`, `exec_module` and a dummy `create_module` method to the `_SixMetaPathImporter` class to recreate the functionality in newer Python versions. The old methods are kept to allow backwards compatibility to python versions < 3.4, which should not work with the new methods. This builds and runs the test-suite with python versions `3.8`, `3.11` and `3.12`. It also builds with Python `2.7`, however, the test suite relies on `collections.abc`, which was only introduced in Python `3.3`, so it is incompatible with older versions. 

The new `find_spec` function uses the `importlib.util.spec_from_loader` function, which was introduced in Python `3.4`, so the import is within the function itself, which avoids incompatibilities with older Python versions, as only Python versions >`3.4` should call that method.

I've also changed a few strings to raw strings, as escaping dots in normal strings gives a syntax warning in python `3.12`.