### PR TITLE
Fixes Syntax Warning for invalid escape sequence

### DIFF
--- a/pyxb/binding/datatypes.py
+++ b/pyxb/binding/datatypes.py
@@ -231,7 +231,7 @@ class duration (basis.simpleTypeDefinition, datetime.timedelta, basis._Represent
     _XsdBaseType = anySimpleType
     _ExpandedName = pyxb.namespace.XMLSchema.createExpandedName('duration')
 
-    __Lexical_re = re.compile('^(?P<neg>-?)P((?P<years>\d+)Y)?((?P<months>\d+)M)?((?P<days>\d+)D)?(?P<Time>T((?P<hours>\d+)H)?((?P<minutes>\d+)M)?(((?P<seconds>\d+)(?P<fracsec>\.\d+)?)S)?)?$')
+    __Lexical_re = re.compile(r'^(?P<neg>-?)P((?P<years>\d+)Y)?((?P<months>\d+)M)?((?P<days>\d+)D)?(?P<Time>T((?P<hours>\d+)H)?((?P<minutes>\d+)M)?(((?P<seconds>\d+)(?P<fracsec>\.\d+)?)S)?)?$')
 
     # We do not use weeks
     __XSDFields = ( 'years', 'months', 'days', 'hours', 'minutes', 'seconds' )
@@ -386,13 +386,13 @@ class _PyXBDateTime_base (basis.simpleTypeDefinition, basis._RepresentAsXsdLiter
     # Map from strptime/strftime formats to the regular expressions we
     # use to extract them.  We're more strict than strptime, so not
     # trying to use that.
-    __PatternMap = { '%Y' : '(?P<negYear>-?)(?P<year>\d{4,})'
-                   , '%m' : '(?P<month>\d{2})'
-                   , '%d' : '(?P<day>\d{2})'
-                   , '%H' : '(?P<hour>\d{2})'
-                   , '%M' : '(?P<minute>\d{2})'
-                   , '%S' : '(?P<second>\d{2})(?P<fracsec>\.\d+)?'
-                   , '%Z' : '(?P<tzinfo>Z|[-+]\d\d:\d\d)' }
+    __PatternMap = { '%Y' : r'(?P<negYear>-?)(?P<year>\d{4,})'
+                   , '%m' : r'(?P<month>\d{2})'
+                   , '%d' : r'(?P<day>\d{2})'
+                   , '%H' : r'(?P<hour>\d{2})'
+                   , '%M' : r'(?P<minute>\d{2})'
+                   , '%S' : r'(?P<second>\d{2})(?P<fracsec>\.\d+)?'
+                   , '%Z' : r'(?P<tzinfo>Z|[-+]\d\d:\d\d)' }
 
     # Cache of compiled regular expressions to parse lexical space of
     # a subclass.

--- a/pyxb/binding/generate.py
+++ b/pyxb/binding/generate.py
@@ -2476,7 +2476,7 @@ from %s import *
 
         pyxb.namespace.XML.validateComponentModel()
 
-    __stripSpaces_re = re.compile('\s\s\s+')
+    __stripSpaces_re = re.compile(r'\s\s\s+')
     def __stripSpaces (self, string):
         return self.__stripSpaces_re.sub(' ', string)
 

--- a/pyxb/utils/templates.py
+++ b/pyxb/utils/templates.py
@@ -40,14 +40,14 @@ import re
 # This expression replaces markers in template text with the value
 # obtained by looking up the marker in a dictionary.
 # %{id} = value
-_substIdPattern = re.compile("%{(?P<id>\w+)}")
+_substIdPattern = re.compile(r"%{(?P<id>\w+)}")
 
 # This expression performs conditional substitution: if the expression
 # provided evaluates to true in a given context, then one value is
 # substituted, otherwise the alternative value is substituted.
 # %{?<cond>??<true>?:<false>?}
 # %{?1 == 2??true?:false?}
-_substConditionalPattern = re.compile("%{\?(?P<expr>.+?)\?\?(?P<true>.*?)(\?:(?P<false>.*?))?\?}", re.MULTILINE + re.DOTALL)
+_substConditionalPattern = re.compile(r"%{\?(?P<expr>.+?)\?\?(?P<true>.*?)(\?:(?P<false>.*?))?\?}", re.MULTILINE + re.DOTALL)
 
 # This expression tests whether an identifier is defined to a non-None
 # value in the context; if so, it replaces the marker with template
@@ -58,11 +58,11 @@ _substConditionalPattern = re.compile("%{\?(?P<expr>.+?)\?\?(?P<true>.*?)(\?:(?P
 # with the value of the test expression.
 # %{?<id>?+<yessubst>?-?<nosubst>}}
 # %{?maybe_text?+?@ is defined to be %{?@}?}
-_substIfDefinedPattern = re.compile("%{\?(?P<id>\w+)(\?\+(?P<repl>.*?))?(\?\-(?P<ndrepl>.*?))?\?}", re.MULTILINE + re.DOTALL)
+_substIfDefinedPattern = re.compile(r"%{\?(?P<id>\w+)(\?\+(?P<repl>.*?))?(\?\-(?P<ndrepl>.*?))?\?}", re.MULTILINE + re.DOTALL)
 
 # The pattern which, if present in the body of a IfDefined block, is
 # replaced by the test expression.
-_substDefinedBodyPattern = re.compile("\?@")
+_substDefinedBodyPattern = re.compile(r"\?@")
 
 def _bodyIfDefinedPattern (match_object, dictionary):
     global _substDefinedBodyPattern

--- a/pyxb/utils/xmlre.py
+++ b/pyxb/utils/xmlre.py
@@ -15,7 +15,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-"""Support for regular expressions conformant to the XML Schema specification.
+r"""Support for regular expressions conformant to the XML Schema specification.
 
 For the most part, XML regular expressions are similar to the POSIX
 ones, and can be handled by the Python C{re} module.  The exceptions
@@ -76,7 +76,7 @@ class RegularExpressionError (ValueError):
 
 _CharClassEsc_re = re.compile(r'\\(?:(?P<cgProp>[pP]{(?P<charProp>[-A-Za-z0-9]+)})|(?P<cgClass>[^pP]))')
 def _MatchCharClassEsc(text, position):
-    """Parse a U{charClassEsc<http://www.w3.org/TR/xmlschema-2/#nt-charClassEsc>} term.
+    r"""Parse a U{charClassEsc<http://www.w3.org/TR/xmlschema-2/#nt-charClassEsc>} term.
 
     This is one of:
 

--- a/tests/trac/test_issue_0078.py
+++ b/tests/trac/test_issue_0078.py
@@ -9,7 +9,7 @@ import pyxb.utils.domutils
 from xml.dom import Node
 
 import os.path
-xsd='''<?xml version="1.0" encoding="UTF-8"?>
+xsd=r'''<?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:simpleType name="tla">
     <xs:restriction base="xs:string">

--- a/tests/trac/test_trac_0047.py
+++ b/tests/trac/test_trac_0047.py
@@ -9,7 +9,7 @@ import pyxb.binding.basis
 import pyxb.utils.domutils
 
 import os.path
-xsd='''<?xml version="1.0" encoding="UTF-8"?>
+xsd=r'''<?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="URN:test-trac-0047" xmlns:gml="URN:test-trac-0047">
         <simpleType name="NilReasonEnumeration">
                 <union>

--- a/tests/utils/test_unicode.py
+++ b/tests/utils/test_unicode.py
@@ -127,11 +127,11 @@ class TestCodePointSet (unittest.TestCase):
 
         c = CodePointSet()
         c.add(']')
-        self.assertEqual('[\]]', c.asPattern())
+        self.assertEqual(r'[\]]', c.asPattern())
         c = CodePointSet()
         c.add('-')
         c.add('+')
-        self.assertEqual('[+\-]', c.asPattern())
+        self.assertEqual(r'[+\-]', c.asPattern())
 
 
     def testAsSingleCharacter (self):

--- a/tests/utils/test_utility.py
+++ b/tests/utils/test_utility.py
@@ -583,8 +583,8 @@ class TestUniqueIdentifier (unittest.TestCase):
 import os
 import re
 class TestGetMatchingFiles (unittest.TestCase):
-    __WXS_re = re.compile('\.wxs$')
-    __NoExt_re = re.compile('(^|\%s)[^\.]+$' % os.sep)
+    __WXS_re = re.compile(r'\.wxs$')
+    __NoExt_re = re.compile(r'(^|\%s)[^\.]+$' % os.sep)
     __directory = None
     def setUp (self):
         self.__directory = tempfile.mkdtemp()

--- a/tests/utils/test_xmlre.py
+++ b/tests/utils/test_xmlre.py
@@ -54,13 +54,13 @@ class TestXMLRE (unittest.TestCase):
         self.assertEqual(2, position)
 
     def testMatchCharProperty (self):
-        self.assertRaises(xmlre.RegularExpressionError, xmlre._MatchAtom, "\pL", 0)
-        self.assertRaises(xmlre.RegularExpressionError, xmlre._MatchAtom, "\p{L", 0)
-        text = "\p{L}"
+        self.assertRaises(xmlre.RegularExpressionError, xmlre._MatchAtom, r"\pL", 0)
+        self.assertRaises(xmlre.RegularExpressionError, xmlre._MatchAtom, r"\p{L", 0)
+        text = r"\p{L}"
         (charset, position) = xmlre._MatchAtom(text, 0)
         self.assertEqual(position, len(text))
         self.assertEqual(charset, unicode.PropertyMap['L'].asPattern())
-        text = "\p{IsCyrillic}"
+        text = r"\p{IsCyrillic}"
         (charset, position) = xmlre._MatchAtom(text, 0)
         self.assertEqual(position, len(text))
         self.assertEqual(charset, unicode.BlockMap['Cyrillic'].asPattern())
@@ -181,7 +181,7 @@ class TestXMLRE (unittest.TestCase):
         self.assertEqual('^(?:Why[ ]not\\?)$', xmlre.XMLToPython(r'Why[ ]not\?'))
 
     def testRegularExpressions (self):
-        text = '[\i-[:]][\c-[:]]*'
+        text = r'[\i-[:]][\c-[:]]*'
         compiled_re = re.compile(xmlre.XMLToPython(text))
         self.assertTrue(compiled_re.match('identifier'))
         self.assertFalse(compiled_re.match('0bad'))


### PR DESCRIPTION
This PR fixes the warnings captured during the test run.
It is replacing strings with raw string specifier similar to what was done in #14.

Let me know if these changes make sense.

Adding more context these fixes are for Python 3.6+ versions:

Here's the reference to the log captured during the CI run:
https://github.com/renalreg/PyXB-X/actions/runs/8002451957/job/21855693309#step:5:224