### PR TITLE
Update generate.py to use python3 explicit relative path for import

### DIFF
--- a/pyxb/binding/generate.py
+++ b/pyxb/binding/generate.py
@@ -1402,9 +1402,9 @@ class _ModuleNaming_mixin (object):
         for (mr, as_path) in six.iteritems(self.__importModulePathMap):
             assert self != mr
             if as_path is not None:
-                aux_imports.append('import %s as %s' % (mr.modulePath(), as_path))
+                aux_imports.append('from . import %s as %s' % (mr.modulePath(), as_path))
             else:
-                aux_imports.append('import %s' % (mr.modulePath(),))
+                aux_imports.append('from . import %s' % (mr.modulePath(),))
         # It's important to sort the imports here, so we reproducibly generate
         # the same code for the same input.  It really doesn't matter *how*
         # they're sorted.

--- a/pyxb/binding/generate.py
+++ b/pyxb/binding/generate.py
@@ -1404,7 +1404,8 @@ class _ModuleNaming_mixin (object):
             if as_path is not None:
                 aux_imports.append('from . import %s as %s' % (mr.modulePath(), as_path))
             else:
-                aux_imports.append('from . import %s' % (mr.modulePath(),))
+                # We did't give as_path name to pybx.* module
+                aux_imports.append('import %s' % (mr.modulePath(),))
         # It's important to sort the imports here, so we reproducibly generate
         # the same code for the same input.  It really doesn't matter *how*
         # they're sorted.


### PR DESCRIPTION
Python3 has specified that importing relative module(path) must be explicit.